### PR TITLE
feat: UrlRewriteContext

### DIFF
--- a/src/Service/UrlRewriteContext.php
+++ b/src/Service/UrlRewriteContext.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Rewrite\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+#[AsAlias(id: 'atoolo_rewrite.url_rewrite_context')]
+class UrlRewriteContext
+{
+    private ?string $scheme = null;
+
+    private ?string $host = null;
+
+    private ?string $basePath = null;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $request = $requestStack->getCurrentRequest();
+        if ($request !== null) {
+            $this->scheme = $request->getScheme();
+            $this->host = $request->getHost();
+            $this->basePath = $request->getBasePath();
+        }
+    }
+
+    public function setScheme(string $scheme): void
+    {
+        $this->scheme = $scheme;
+    }
+
+    public function setHost(string $host): void
+    {
+        $this->host = $host;
+    }
+
+    public function setBasePath(string $basePath): void
+    {
+        $this->basePath = $basePath;
+    }
+
+    public function getScheme(): ?string
+    {
+        return $this->scheme;
+    }
+
+    public function getHost(): ?string
+    {
+        return $this->host;
+    }
+
+    public function getBasePath(): ?string
+    {
+        return $this->basePath;
+    }
+}

--- a/test/Service/UrlRewriteContextTest.php
+++ b/test/Service/UrlRewriteContextTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Rewrite\Test\Service;
+
+use Atoolo\Rewrite\Service\UrlRewriteContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+#[CoversClass(UrlRewriteContext::class)]
+class UrlRewriteContextTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testConstructor(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $request = $this->createMock(Request::class);
+        $requestStack->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+        $request->expects($this->once())
+            ->method('getScheme')
+            ->willReturn('https');
+        $request->expects($this->once())
+            ->method('getHost')
+            ->willReturn('example.com');
+        $request->expects($this->once())
+            ->method('getBasePath')
+            ->willReturn('/base/path');
+
+        $context = new UrlRewriteContext($requestStack);
+
+        $this->assertSame('https', $context->getScheme());
+        $this->assertSame('example.com', $context->getHost());
+        $this->assertSame('/base/path', $context->getBasePath());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSetScheme(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $context = new UrlRewriteContext($requestStack);
+
+        $context->setScheme('https');
+        $this->assertSame('https', $context->getScheme());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSetHost(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $context = new UrlRewriteContext($requestStack);
+
+        $context->setHost('example.com');
+        $this->assertSame('example.com', $context->getHost());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSetBasePath(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $context = new UrlRewriteContext($requestStack);
+
+        $context->setBasePath('/base/path');
+        $this->assertSame('/base/path', $context->getBasePath());
+    }
+
+}


### PR DESCRIPTION
For some rewriters it is necessary to know the base URL. This is usually the URL of the current page. However, this cannot always be determined directly via the request. For example, if the page reloads data via the GraphQL interface. This context must then be set accordingly.