### PR TITLE
feat: same navigation url rewriter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "symfony/dependency-injection": "^6.3 || ^7.0",
         "symfony/framework-bundle": "^6.3 || ^7.1",
         "symfony/http-kernel": "^6.3 || ^7.0",
-        "symfony/yaml": "^6.3 || ^7.0"
+        "symfony/yaml": "^6.3 || ^7.0",
+        "atoolo/resource-bundle": "dev-main"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/src/Service/SameNavigationUrlRewriteHandler.php
+++ b/src/Service/SameNavigationUrlRewriteHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Rewrite\Service;
+
+use Atoolo\Resource\ResourceLocation;
+use Atoolo\Resource\Service\PParameterService;
+use Atoolo\Rewrite\Dto\Url;
+use Atoolo\Rewrite\Dto\UrlRewriterHandlerContext;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsAlias(id: 'atoolo_rewrite.url_rewrite_handler.same_navigation')]
+class SameNavigationUrlRewriteHandler implements UrlRewriterHandler
+{
+    public function __construct(
+        private readonly UrlRewriteContext $urlRewriteContext,
+        #[Autowire(service: 'atoolo_resource.p_parameter_service')]
+        private readonly PParameterService $pParameterService,
+    ) {}
+
+    public function rewrite(
+        Url $url,
+        UrlRewriterHandlerContext $context,
+    ): Url {
+        if ($this->urlRewriteContext->getResourceLocation() === null) {
+            return $url;
+        }
+        if ($url->host !== null) {
+            return $url;
+        }
+        if (empty($url->path)) {
+            return $url;
+        }
+
+        $pParameter = $this->pParameterService->getPParameterForForeignParent(
+            ResourceLocation::of($this->urlRewriteContext->getResourceLocation()),
+            ResourceLocation::ofPath($url->path),
+        );
+
+        return $url->toBuilder()->param('p', $pParameter)->build();
+    }
+}

--- a/src/Service/UrlRewriteContext.php
+++ b/src/Service/UrlRewriteContext.php
@@ -16,6 +16,8 @@ class UrlRewriteContext
 
     private ?string $basePath = null;
 
+    private ?string $resourceLocation = null;
+
     public function __construct(RequestStack $requestStack)
     {
         $request = $requestStack->getCurrentRequest();
@@ -41,6 +43,11 @@ class UrlRewriteContext
         $this->basePath = $basePath;
     }
 
+    public function setResourceLocation(string $resourceLocation): void
+    {
+        $this->resourceLocation = $resourceLocation;
+    }
+
     public function getScheme(): ?string
     {
         return $this->scheme;
@@ -54,5 +61,10 @@ class UrlRewriteContext
     public function getBasePath(): ?string
     {
         return $this->basePath;
+    }
+
+    public function getResourceLocation(): ?string
+    {
+        return $this->resourceLocation;
     }
 }

--- a/test/Service/SameNavigationUrlRewriteHandlerTest.php
+++ b/test/Service/SameNavigationUrlRewriteHandlerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Rewrite\Test\Service;
+
+use Atoolo\Resource\Service\PParameterService;
+use Atoolo\Rewrite\Dto\Url;
+use Atoolo\Rewrite\Dto\UrlRewriterHandlerContext;
+use Atoolo\Rewrite\Service\SameNavigationUrlRewriteHandler;
+use Atoolo\Rewrite\Service\UrlRewriteContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SameNavigationUrlRewriteHandler::class)]
+class SameNavigationUrlRewriteHandlerTest extends TestCase
+{
+    private SameNavigationUrlRewriteHandler $handler;
+    private UrlRewriteContext $urlRewriteContext;
+    private PParameterService $pParameterService;
+    private UrlRewriterHandlerContext $handlerContext;
+
+    /**
+     * @throws Exception
+     */
+    protected function setUp(): void
+    {
+        $this->urlRewriteContext = $this->createMock(UrlRewriteContext::class);
+        $this->pParameterService = $this->createMock(PParameterService::class);
+
+        $this->handler = new SameNavigationUrlRewriteHandler(
+            $this->urlRewriteContext,
+            $this->pParameterService,
+        );
+        $this->handlerContext = $this->createStub(UrlRewriterHandlerContext::class);
+    }
+
+    public function testRewriteWithNullResourceLocation(): void
+    {
+        $url = Url::builder()->build();
+
+        $this->urlRewriteContext->method('getResourceLocation')->willReturn(null);
+
+        $result = $this->handler->rewrite($url, $this->handlerContext);
+
+        $this->assertSame($url, $result);
+    }
+
+    public function testRewriteWithNonNullHost(): void
+    {
+        $url = Url::builder()->host('www.example.com')->build();
+        $this->urlRewriteContext->method('getResourceLocation')->willReturn('/path');
+        $result = $this->handler->rewrite($url, $this->handlerContext);
+
+        $this->assertSame($url, $result);
+    }
+
+    public function testRewriteWithEmptyPath(): void
+    {
+        $url = Url::builder()->path('')->build();
+        $this->urlRewriteContext->method('getResourceLocation')->willReturn('/path');
+        $result = $this->handler->rewrite($url, $this->handlerContext);
+
+        $this->assertSame($url, $result);
+    }
+
+    public function testRewriteWithValidPath(): void
+    {
+        $url = Url::builder()->path('/path/bar')->build();
+
+        $this->urlRewriteContext->method('getResourceLocation')->willReturn('/path/foo');
+        $this->pParameterService->method('getPParameterForForeignParent')->willReturn('pValue');
+
+        $result = $this->handler->rewrite($url, $this->handlerContext);
+
+        $this->assertEquals('pValue', $result->params['p'] ?? null);
+    }
+}

--- a/test/Service/UrlRewriteContextTest.php
+++ b/test/Service/UrlRewriteContextTest.php
@@ -77,4 +77,15 @@ class UrlRewriteContextTest extends TestCase
         $this->assertSame('/base/path', $context->getBasePath());
     }
 
+    /**
+     * @throws Exception
+     */
+    public function testSetResourceLocation(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $context = new UrlRewriteContext($requestStack);
+
+        $context->setResourceLocation('/path');
+        $this->assertSame('/path', $context->getResourceLocation());
+    }
 }


### PR DESCRIPTION
I make cases articles should be added to another navigation node. An example of this is search results from a section search. Its hits should be sorted (only for this search page) below the search in the navigation. This is achieved using the P parameter. The new URL rewriter generates the parameter and attaches it to the URL.